### PR TITLE
Accessibility parameters not being handled

### DIFF
--- a/src/components/route-link/route-link.tsx
+++ b/src/components/route-link/route-link.tsx
@@ -23,7 +23,7 @@ export class RouteLink {
   @Prop() exact: boolean = false;
   @Prop() strict: boolean = true;
 
-  /**
+ /**
    *  Custom tag to use instead of an anchor
    */
   @Prop() custom: string = 'a';
@@ -36,8 +36,15 @@ export class RouteLink {
   @Prop() history: RouterHistory;
   @Prop() location: LocationSegments;
   @Prop() root: string;
+  
+  @Prop() ariaHasPopup: string;
+  @Prop() id: string;
+  @Prop() ariaPosInset: string;
+  @Prop() ariaSetSize: number;
+  @Prop() ariaLabel: string;
 
   @State() match: MatchResults | null = null;
+  
 
   componentWillLoad() {
     this.computeMatch();
@@ -92,8 +99,13 @@ export class RouteLink {
         href: this.url,
         title: this.anchorTitle,
         role: this.anchorRole,
-        tabindex: this.anchorTabIndex
-      }
+        tabindex: this.anchorTabIndex,
+        'aria-haspopup': this.ariaHasPopup,
+        id: this.id,
+        'aria-posinset': this.ariaPosInset,
+        'aria-setsize': this.ariaSetSize,
+        'aria-label': this.ariaLabel
+       }
     }
     return (
       <this.custom {...anchorAttributes}>


### PR DESCRIPTION
Hi,
Hi, This is not handling attributes which are required for accessibility . Without these our links will not be accessibility compatible. Please handle these attributes:
- aria-haspopup
- id
- aria-posinset
- aria-setsize
- aria-label